### PR TITLE
publish: allow using the default exchange ""

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Publishing pushes data from stdin or a file to an exchange.
     OPTIONS:
         -c, --content-type <content_type>    Content type such as application/json. Inferred from filename if
                                              possible.
-        -e, --exchange <exchange>            Exchange to publish to
+        -e, --exchange <exchange>            Exchange to publish to [default ]
         -f, --file <file>                    Filename (- is stdin) [default: -]
         -H, --header <header>...             Header on the form "My-Header: Value"
         -r, --routing-key <routing_key>      Routing key [default: ]
@@ -104,7 +104,7 @@ Content-type is inferred if possible.
 Using the `replyTo` header.
 
     $ CONF=conf.json rabbiteer publish -e myservice -r somecall --rpc -f ./foo.json
-    
+
 Calls `myservice/somecall` using the contents of file `foo.json` and sets up
 a `replyTo` header and waits the the rpc reply. The reply will be printed
 to stdout.

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ fn _main() -> Result<(),RbtError> {
                          .short("e")
                          .long("exchange")
                          .takes_value(true)
-                         .required(true))
+                         .default_value(""))
                     .arg(Arg::with_name("routing_key")
                          .help("Routing key")
                          .short("r")


### PR DESCRIPTION
The default exchange has some interesting properties, effectively allowing you to
publish "directly" to a queue, even though that's not actually how rabbitmq works
internally.

This PR allows you to publish to that default exchange by making the parameter
optional and defaulting to the empty string.